### PR TITLE
Add /reload endpoint for hot reloading

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -16,6 +16,7 @@ Martin data is available via the HTTP `GET` endpoints:
 | `/font/{font1},…,{fontN}/{start}-{end}`  | [Composite Font source](sources-fonts.md)      |
 | `/style/{style}`                         | [Style source](sources-styles.md)              |
 | `/health`                                | Martin server health check: returns 200 `OK`   |
+| `/reload`                                | Reload auto published tables and functions |
 
 ### Duplicate Source ID
 

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -42,6 +42,13 @@ impl TileSources {
             .collect()
     }
 
+    pub fn replace(&self, other: TileSources) {
+        self.0.clear();
+        for (k, v) in other.0.into_iter() {
+            self.0.insert(k, v);
+        }
+    }
+
     pub fn get_source(&self, id: &str) -> actix_web::Result<TileInfoSource> {
         Ok(self
             .0

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -13,6 +13,9 @@ pub use tiles::{DynTileSource, TileRequest};
 mod tiles_info;
 pub use tiles_info::{SourceIDsRequest, merge_tilejson};
 
+mod reload;
+pub use reload::reload_sources;
+
 #[cfg(feature = "sprites")]
 mod sprites;
 

--- a/martin/src/srv/reload.rs
+++ b/martin/src/srv/reload.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+use actix_web::{HttpResponse, Result as ActixResult, route};
+use actix_web::web::Data;
+
+use crate::config::Config;
+use crate::source::{TileSources};
+use crate::srv::server::{map_internal_error, Catalog};
+use crate::utils::OptMainCache;
+#[cfg(feature = "sprites")]
+use crate::sprites::SpriteSources;
+#[cfg(feature = "fonts")]
+use crate::fonts::FontSources;
+#[cfg(feature = "styles")]
+use crate::styles::StyleSources;
+
+#[route("/reload", method = "GET", method = "POST")]
+pub async fn reload_sources(
+    config: Data<Arc<Mutex<Config>>>,
+    tiles: Data<TileSources>,
+    cache: Data<OptMainCache>,
+    catalog: Data<Arc<RwLock<Catalog>>>,
+    #[cfg(feature = "sprites")] sprites: Data<SpriteSources>,
+    #[cfg(feature = "fonts")] fonts: Data<FontSources>,
+    #[cfg(feature = "styles")] styles: Data<StyleSources>,
+) -> ActixResult<HttpResponse> {
+    let mut cfg = config.lock().await;
+    let new_sources = cfg
+        .reload_tile_sources(cache.get_ref().clone())
+        .await
+        .map_err(map_internal_error)?;
+    tiles.replace(new_sources);
+
+    let mut cat = catalog.write().await;
+    *cat = Catalog {
+        tiles: tiles.get_catalog(),
+        #[cfg(feature = "sprites")]
+        sprites: sprites.get_catalog().map_err(map_internal_error)?,
+        #[cfg(feature = "fonts")]
+        fonts: fonts.get_catalog(),
+        #[cfg(feature = "styles")]
+        styles: styles.get_catalog(),
+    };
+    drop(cat);
+    Ok(HttpResponse::Ok().finish())
+}


### PR DESCRIPTION
## Summary
- implement hot-reloadable tile sources
- expose reload endpoint
- update catalog building logic with a RwLock
- document `/reload` endpoint

## Testing
- `cargo check` *(fails: Could not connect to server)*