### PR TITLE
Add /reload endpoint for hot reloading

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -16,6 +16,7 @@ Martin data is available via the HTTP `GET` endpoints:
 | `/font/{font1},…,{fontN}/{start}-{end}`  | [Composite Font source](sources-fonts.md)      |
 | `/style/{style}`                         | [Style source](sources-styles.md)              |
 | `/health`                                | Martin server health check: returns 200 `OK`   |
+| `/reload`                                | Reload auto published tables and functions |
 
 ### Duplicate Source ID
 

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -42,6 +42,13 @@ impl TileSources {
             .collect()
     }
 
+    pub fn replace(&self, other: TileSources) {
+        self.0.clear();
+        for (k, v) in other.0.into_iter() {
+            self.0.insert(k, v);
+        }
+    }
+
     pub fn get_source(&self, id: &str) -> actix_web::Result<TileInfoSource> {
         Ok(self
             .0

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -13,6 +13,9 @@ pub use tiles::{DynTileSource, TileRequest};
 mod tiles_info;
 pub use tiles_info::{SourceIDsRequest, merge_tilejson};
 
+mod reload;
+pub use reload::reload_sources;
+
 #[cfg(feature = "sprites")]
 mod sprites;
 

--- a/martin/src/srv/reload.rs
+++ b/martin/src/srv/reload.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+use actix_web::{HttpResponse, Result as ActixResult, route};
+use actix_web::web::Data;
+
+use crate::config::Config;
+use crate::source::{TileSources};
+use crate::srv::server::{map_internal_error, Catalog};
+use crate::utils::OptMainCache;
+#[cfg(feature = "sprites")]
+use crate::sprites::SpriteSources;
+#[cfg(feature = "fonts")]
+use crate::fonts::FontSources;
+#[cfg(feature = "styles")]
+use crate::styles::StyleSources;
+
+#[route("/reload", method = "GET", method = "POST")]
+pub async fn reload_sources(
+    config: Data<Arc<Mutex<Config>>>,
+    tiles: Data<TileSources>,
+    cache: Data<OptMainCache>,
+    catalog: Data<Arc<RwLock<Catalog>>>,
+    #[cfg(feature = "sprites")] sprites: Data<SpriteSources>,
+    #[cfg(feature = "fonts")] fonts: Data<FontSources>,
+    #[cfg(feature = "styles")] styles: Data<StyleSources>,
+) -> ActixResult<HttpResponse> {
+    let mut cfg = config.lock().await;
+    let new_sources = cfg
+        .reload_tile_sources(cache.get_ref().clone())
+        .await
+        .map_err(map_internal_error)?;
+    tiles.replace(new_sources);
+
+    let mut cat = catalog.write().await;
+    *cat = Catalog {
+        tiles: tiles.get_catalog(),
+        #[cfg(feature = "sprites")]
+        sprites: sprites.get_catalog().map_err(map_internal_error)?,
+        #[cfg(feature = "fonts")]
+        fonts: fonts.get_catalog(),
+        #[cfg(feature = "styles")]
+        styles: styles.get_catalog(),
+    };
+    drop(cat);
+    Ok(HttpResponse::Ok().finish())
+}

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -9,6 +9,8 @@ use actix_web::http::header::CACHE_CONTROL;
 use actix_web::middleware::TrailingSlash;
 use actix_web::web::Data;
 use actix_web::{App, HttpResponse, HttpServer, Responder, middleware, route, web};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use futures::TryFutureExt;
 #[cfg(feature = "lambda")]
 use lambda_web::{is_running_on_lambda, run_actix_on_lambda};
@@ -108,12 +110,13 @@ async fn get_health() -> impl Responder {
     wrap = "middleware::Compress::default()"
 )]
 #[allow(clippy::unused_async)]
-async fn get_catalog(catalog: Data<Catalog>) -> impl Responder {
-    HttpResponse::Ok().json(catalog)
+async fn get_catalog(catalog: Data<Arc<RwLock<Catalog>>>) -> impl Responder {
+    HttpResponse::Ok().json(&*catalog.read().await)
 }
 
 pub fn router(cfg: &mut web::ServiceConfig, #[allow(unused_variables)] usr_cfg: &SrvConfig) {
     cfg.service(get_health)
+        .service(crate::srv::reload::reload_sources)
         .service(get_catalog)
         .service(get_source_info)
         .service(get_tile);
@@ -152,7 +155,7 @@ type Server = Pin<Box<dyn Future<Output = MartinResult<()>>>>;
 
 /// Create a future for an Actix web server together with the listening address.
 pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server, String)> {
-    let catalog = Catalog::new(&state)?;
+    let catalog = std::sync::Arc::new(tokio::sync::RwLock::new(Catalog::new(&state)?));
 
     let keep_alive = Duration::from_secs(config.keep_alive.unwrap_or(KEEP_ALIVE_DEFAULT));
     let worker_processes = config.worker_processes.unwrap_or_else(num_cpus::get);
@@ -168,7 +171,8 @@ pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server
 
         let app = App::new()
             .app_data(Data::new(state.tiles.clone()))
-            .app_data(Data::new(state.cache.clone()));
+            .app_data(Data::new(state.cache.clone()))
+            .app_data(Data::new(state.config.clone()));
 
         #[cfg(feature = "sprites")]
         let app = app.app_data(Data::new(state.sprites.clone()));

--- a/martin/tests/mb_server_test.rs
+++ b/martin/tests/mb_server_test.rs
@@ -20,9 +20,9 @@ macro_rules! create_app {
         let state = mock_sources(mock_cfg($sources)).await.0;
         ::actix_web::test::init_service(
             ::actix_web::App::new()
-                .app_data(actix_web::web::Data::new(
-                    ::martin::srv::Catalog::new(&state).unwrap(),
-                ))
+                .app_data(actix_web::web::Data::new(std::sync::Arc::new(
+                    tokio::sync::RwLock::new(::martin::srv::Catalog::new(&state).unwrap()),
+                )))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
                 .app_data(actix_web::web::Data::new(SrvConfig::default()))

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -24,9 +24,9 @@ macro_rules! create_app {
         let state = mock_sources(cfg).await.0;
         ::actix_web::test::init_service(
             ::actix_web::App::new()
-                .app_data(actix_web::web::Data::new(
-                    ::martin::srv::Catalog::new(&state).unwrap(),
-                ))
+                .app_data(actix_web::web::Data::new(std::sync::Arc::new(
+                    tokio::sync::RwLock::new(::martin::srv::Catalog::new(&state).unwrap()),
+                )))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
                 .app_data(actix_web::web::Data::new(SrvConfig::default()))
@@ -1097,9 +1097,9 @@ tables:
     let state = mock_sources(cfg.clone()).await.0;
     let app = ::actix_web::test::init_service(
         ::actix_web::App::new()
-            .app_data(actix_web::web::Data::new(
-                ::martin::srv::Catalog::new(&state).unwrap(),
-            ))
+            .app_data(actix_web::web::Data::new(std::sync::Arc::new(
+                tokio::sync::RwLock::new(::martin::srv::Catalog::new(&state).unwrap()),
+            )))
             .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
             .app_data(actix_web::web::Data::new(state.tiles))
             .app_data(actix_web::web::Data::new(SrvConfig::default()))

--- a/martin/tests/pmt_server_test.rs
+++ b/martin/tests/pmt_server_test.rs
@@ -20,9 +20,9 @@ macro_rules! create_app {
         let state = mock_sources(mock_cfg($sources)).await.0;
         ::actix_web::test::init_service(
             ::actix_web::App::new()
-                .app_data(actix_web::web::Data::new(
-                    ::martin::srv::Catalog::new(&state).unwrap(),
-                ))
+                .app_data(actix_web::web::Data::new(std::sync::Arc::new(
+                    tokio::sync::RwLock::new(::martin::srv::Catalog::new(&state).unwrap()),
+                )))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
                 .app_data(actix_web::web::Data::new(SrvConfig::default()))


### PR DESCRIPTION
## Summary
- implement hot reloadable tile sources
- expose reload endpoint
- update catalog building logic with a RwLock
- document `/reload` endpoint
- fix reload route to register before catch-all tile routes

## Testing
- `cargo check` *(failed: Could not connect to server)*