### PR TITLE
Add incremental publish reload option

### DIFF
--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -107,6 +107,14 @@ postgres:
       # Optionally set how source ID should be generated based on the function's name and schema
       source_id_format: '{schema}.{function}'
 
+  # When reloading sources via /reload, only add or remove changed tables
+  # without rebuilding all existing ones
+  incremental_publish: true
+
+  # Watch for schema changes and publish incrementally in the background.
+  # Possible values: off, info, debug
+  watch_mode: info
+
   # Associative arrays of table sources
   tables:
     table_source_id:

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -49,6 +49,29 @@ impl TileSources {
         }
     }
 
+    #[must_use]
+    pub fn contains(&self, id: &str) -> bool {
+        self.0.contains_key(id)
+    }
+
+    pub fn insert(&self, id: String, src: TileInfoSource) {
+        self.0.insert(id, src);
+    }
+
+    pub fn remove(&self, id: &str) {
+        self.0.remove(id);
+    }
+
+    #[must_use]
+    pub fn ids(&self) -> Vec<String> {
+        self.0.iter().map(|v| v.key().clone()).collect()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<(String, TileInfoSource)> {
+        self.0.into_iter().collect()
+    }
+
     pub fn get_source(&self, id: &str) -> actix_web::Result<TileInfoSource> {
         Ok(self
             .0


### PR DESCRIPTION
## Summary
- add `watch_mode` option with enum to config
- automatically watch for schema changes when `watch_mode` is set
- update `/reload` docs with incremental and watch settings

## Testing
- `cargo check` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*