### PR TITLE
Add incremental reload mode

### DIFF
--- a/debian/config.yaml
+++ b/debian/config.yaml
@@ -10,6 +10,9 @@ worker_processes: 8
 # Amount of memory (in MB) to use for caching tiles [default: 512, 0 to disable]
 cache_size_mb: 512
 
+# How the `/reload` endpoint updates tile sources [default: full]
+reload_mode: full
+
 # see https://maplibre.org/martin/config-file.html
 
 # postgres:

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -38,6 +38,11 @@ worker_processes: 8
 # Amount of memory (in MB) to use for caching tiles [default: 512, 0 to disable]
 cache_size_mb: 1024
 
+# How the `/reload` endpoint updates tile sources [default: full]
+#   full - rebuild all sources
+#   incremental - add or remove only changed sources
+reload_mode: full
+
 # If the client accepts multiple compression formats, and the tile source is not pre-compressed, which compression should be used. `gzip` is faster, but `brotli` is smaller, and may be faster with caching.  Default could be different depending on Martin version.
 preferred_encoding: gzip
 

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -16,7 +16,7 @@ Martin data is available via the HTTP `GET` endpoints:
 | `/font/{font1},…,{fontN}/{start}-{end}`  | [Composite Font source](sources-fonts.md)      |
 | `/style/{style}`                         | [Style source](sources-styles.md)              |
 | `/health`                                | Martin server health check: returns 200 `OK`   |
-| `/reload`                                | Reload auto published tables and functions |
+| `/reload`                                | Reload auto published tables and functions (mode controlled by `reload_mode`) |
 
 ### Duplicate Source ID
 

--- a/martin/src/config.rs
+++ b/martin/src/config.rs
@@ -29,6 +29,19 @@ use crate::{IdResolver, MartinResult};
 
 pub type UnrecognizedValues = HashMap<String, serde_yaml::Value>;
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReloadMode {
+    Full,
+    Incremental,
+}
+
+impl Default for ReloadMode {
+    fn default() -> Self {
+        ReloadMode::Full
+    }
+}
+
 pub struct ServerState {
     pub cache: OptMainCache,
     pub tiles: TileSources,
@@ -76,6 +89,9 @@ pub struct Config {
     #[cfg(feature = "fonts")]
     #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
     pub fonts: OptOneMany<PathBuf>,
+
+    #[serde(default)]
+    pub reload_mode: ReloadMode,
 
     #[serde(flatten)]
     pub unrecognized: UnrecognizedValues,

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -49,6 +49,24 @@ impl TileSources {
         }
     }
 
+    /// Incrementally update tile sources in place. Existing sources are kept,
+    /// new ones are added, and sources missing in `other` are removed.
+    pub fn sync_incremental(&self, other: TileSources) {
+        use std::collections::HashSet;
+
+        let mut seen = HashSet::new();
+        for (k, v) in other.0.into_iter() {
+            seen.insert(k.clone());
+            self.0.entry(k).or_insert(v);
+        }
+
+        for k in self.0.iter().map(|e| e.key().clone()).collect::<Vec<_>>() {
+            if !seen.contains(&k) {
+                self.0.remove(&k);
+            }
+        }
+    }
+
     pub fn get_source(&self, id: &str) -> actix_web::Result<TileInfoSource> {
         Ok(self
             .0


### PR DESCRIPTION
## Summary
- add `reload_mode` config option and enum
- support incremental reloads via `/reload` endpoint
- document new config field

## Testing
- `cargo test --locked --offline --no-run` *(fails: could not download crates)*