### PR TITLE
Support json columns

### DIFF
--- a/docs/src/sources-pg-tables.md
+++ b/docs/src/sources-pg-tables.md
@@ -1,6 +1,6 @@
 # PostgreSQL Table Sources
 
-Table Source is a database table which can be used to query [vector tiles](https://github.com/mapbox/vector-tile-spec). If a [PostgreSQL connection string](pg-connections.md) is given, Martin will publish all tables as data sources if they have at least one geometry column. If geometry column SRID is 0, a default SRID must be set, or else that geo-column/table will be ignored. All non-geometry table columns will be published as vector tile feature tags (properties).
+Table Source is a database table which can be used to query [vector tiles](https://github.com/mapbox/vector-tile-spec). If a [PostgreSQL connection string](pg-connections.md) is given, Martin will publish all tables as data sources if they have at least one geometry column. If geometry column SRID is 0, a default SRID must be set, or else that geo-column/table will be ignored. All non-geometry table columns will be published as vector tile feature tags (properties). Columns of `json` or `jsonb` type are automatically cast to text so their contents appear in the resulting vector tiles.
 
 ## Modifying Tilejson
 


### PR DESCRIPTION
## Summary
- include JSON and JSONB columns when auto publishing tables by casting them to text
- document JSON column behavior

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_b_683f49ba319c832b8024b8c67e9f1cdc